### PR TITLE
New push for different configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ test/temp*
 # SMS and pypsa files
 *.nc
 *.txt
+!uc_solverconfig_grb.txt

--- a/pysmspp/data/blocks/ThermalUnitBlock.csv
+++ b/pysmspp/data/blocks/ThermalUnitBlock.csv
@@ -6,7 +6,7 @@ ThermalUnitBlock,MaxPower,Variable,Variable,double,-|TimeHorizon,MW,,optional,Ma
 ThermalUnitBlock,StartUpCost,Variable,Variable,double,-|TimeHorizon,USD,,optional,Start-up cost of the unit
 ThermalUnitBlock,QuadTerm,Variable,Variable,double,-|TimeHorizon,-,,optional,Quadratic term of the cost function
 ThermalUnitBlock,LinearTerm,Variable,Variable,double,-|TimeHorizon,USD/MWh,,optional,Linear term of the cost function
-ThermalUnitBlock,ConstantTerm,Variable,Variable,double,-|TimeHorizon,USD,,optional,Constant term of the cost function
+ThermalUnitBlock,ConstTerm,Variable,Variable,double,-|TimeHorizon,USD,,optional,Constant term of the cost function
 ThermalUnitBlock,FixedConsumption,Variable,Variable,double,1|TimeHorizon,-,,optional,Fixed consumption
 ThermalUnitBlock,MinUpTime,Variable,Variable,double,-,h,,optional,Minimum up time of the unit
 ThermalUnitBlock,MinDownTime,Variable,Variable,double,-,h,,optional,Minimum down time of the unit

--- a/pysmspp/data/configs/InvestmentBlock/uc_solverconfig_grb.txt
+++ b/pysmspp/data/configs/InvestmentBlock/uc_solverconfig_grb.txt
@@ -1,0 +1,31 @@
+BlockSolverConfig  # The name of the configuration
+
+1 # The configuration is "differential"
+1 # Number of solvers
+
+# Names of the solvers
+GRBMILPSolver
+
+1 # Number of ComputeConfigs
+
+# ------ ComputeConfig 0 ------
+ComputeConfig      # Type of the object
+1                  # Not differential
+
+1  # Number of integer parameters
+intLogVerb 1
+
+2  # Number of double parameters
+dblAAccSol 1e-04
+dblMaxTime 3600
+
+1                  # Number of string parameters
+strOutputFile uc_output.lp
+
+0  # Number of vector-of-int parameters
+0  # Number of vector-of-double parameters
+0  # Number of vector-of-string parameters
+
+# Extra configuration
+* # [none]
+# -----------------------------

--- a/pysmspp/data/configs/uc_solverconfig_grb.txt
+++ b/pysmspp/data/configs/uc_solverconfig_grb.txt
@@ -1,0 +1,31 @@
+BlockSolverConfig  # The name of the configuration
+
+1 # The configuration is "differential"
+1 # Number of solvers
+
+# Names of the solvers
+GRBMILPSolver
+
+1 # Number of ComputeConfigs
+
+# ------ ComputeConfig 0 ------
+ComputeConfig      # Type of the object
+1                  # Not differential
+
+1  # Number of integer parameters
+intLogVerb 1
+
+2  # Number of double parameters
+dblAAccSol 1e-04
+dblMaxTime 3600
+
+1                  # Number of string parameters
+strOutputFile uc_output.lp
+
+0  # Number of vector-of-int parameters
+0  # Number of vector-of-double parameters
+0  # Number of vector-of-string parameters
+
+# Extra configuration
+* # [none]
+# -----------------------------

--- a/pysmspp/smspp_tools.py
+++ b/pysmspp/smspp_tools.py
@@ -120,6 +120,7 @@ class SMSPPSolverTool:
             raise FileNotFoundError(f"Network file {self.fp_network} does not exist.")
 
         start_time = time.time()
+        print(self.calculate_executable_call())
         result = subprocess.run(
             self.calculate_executable_call(),
             capture_output=True,


### PR DESCRIPTION
- Changes ConstantTerm into ConstTerm for ThermalUnitBlocks
- Added solverconfig with gurobi as default as possible options. To decide whether to create an appropriate folder
- print self.excecutable_call. No flag added, nor logger (not available), so just a static print to keep changes simple.

Comment: probably a flag to print all the data memorized in self could be useful to track performances